### PR TITLE
Fix find_aa_candidates() regex to match tRNA names with numeric suffixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -90,6 +90,8 @@
 
 * `modomics_mods()` maps MODOMICS tRNA modifications onto reference sequences using bundled data, eliminating the need for internet access. Use `modomics_organisms()` to list organisms with cached data. Falls back to `fetch_modomics_mods()` for unsupported organisms (#11).
 
+* `modomics_mods()` now correctly matches reference tRNA names with numeric suffixes such as tRNA-Ile2 (#29).
+
 * `plot_volcano()` creates a labeled volcano plot from `tidy_deseq_results()` output, with significant points highlighted and labeled using ggrepel.
 
 * `tabulate_deseq()` creates a formatted gt table of the top significant tRNAs from `tidy_deseq_results()` output, sorted by p-value. The table now includes zebra striping, search, column sorting, and pagination.

--- a/R/modomics.R
+++ b/R/modomics.R
@@ -495,7 +495,7 @@ find_aa_candidates <- function(subtype, fasta_names) {
 
   candidate_idx <- integer(0)
   for (pat in patterns) {
-    aa_regex <- paste0("[-_]", pat, "[-_(]")
+    aa_regex <- paste0("[-_]", pat, "\\d*[-_(]")
     idx <- grep(aa_regex, fasta_names, ignore.case = TRUE)
     candidate_idx <- union(candidate_idx, idx)
   }

--- a/tests/testthat/test-modomics.R
+++ b/tests/testthat/test-modomics.R
@@ -127,6 +127,24 @@ test_that("find_aa_candidates matches amino acid in FASTA names", {
   expect_equal(gly_idx, 3L)
 })
 
+test_that("find_aa_candidates matches numeric suffix variants (#29)", {
+  fasta_names <- c(
+    "tRNA-Ile-GAT-1",
+    "tRNA-Ile2-CAT-1",
+    "tRNA-Lys3-CTT-1",
+    "tRNA-Alab-AGC-1"
+  )
+
+  ile_idx <- find_aa_candidates("Ile", fasta_names)
+  expect_equal(sort(ile_idx), c(1L, 2L))
+
+  lys_idx <- find_aa_candidates("Lys", fasta_names)
+  expect_equal(lys_idx, 3L)
+
+  ala_idx <- find_aa_candidates("Ala", fasta_names)
+  expect_equal(length(ala_idx), 0L)
+})
+
 test_that("find_aa_candidates maps Ini to Met variants", {
   fasta_names <- c(
     "tRNA-Met-CAT-1",


### PR DESCRIPTION
## Summary

- Fixes #29.
- `find_aa_candidates()` in `R/modomics.R` built the regex `[-_]<subtype>[-_(]`, whose suffix character class excludes digits. For `subtype = "Ile"` this matched `tRNA-Ile-GAT` but silently failed on `tRNA-Ile2-CAT`, causing `modomics_mods()` to return zero annotations for any Ile2-style tRNA without warning.
- Allow optional digits between the subtype name and the suffix delimiter (`[-_]<pat>\d*[-_(]`). Generalizes to `Ile2`, `Lys3`, etc. without special-casing each amino acid.

## Test plan

- [x] `devtools::test(filter = '^modomics')` passes (44 PASS, 0 FAIL).
- [x] New regression test `find_aa_candidates matches numeric suffix variants (#29)` covers `tRNA-Ile2`/`tRNA-Lys3` positive cases and confirms `tRNA-Alab` is still rejected when searching for `Ala` (no over-permissiveness).
- [x] Existing `find_aa_candidates` tests still pass.