### PR TITLE
Surface MODOMICS alignment failures; document remaining SeC gaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 * `prep_mod_heatmap()` prepares bcerror delta data for `plot_mod_heatmap()` by joining Sprinzl coordinates, annotating known modifications, and shortening tRNA labels.
 
-* `identity_elements()`, `tertiary_contacts()`, and `modomics_mods()` documentation now notes that selenocysteine tRNA (SeC) is not currently supported (#30).
+* `identity_elements()` and `tertiary_contacts()` documentation now notes that selenocysteine tRNA (SeC) is not currently supported because no SeC determinants, antideterminants, or Sprinzl coordinates are bundled (#30).
 
 * `identity_elements()` returns experimentally validated tRNA aminoacylation identity elements (determinants and antideterminants) for a given organism, based on Giege & Eriani (2023). Use `identity_organisms()` to list supported organisms.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * `prep_mod_heatmap()` prepares bcerror delta data for `plot_mod_heatmap()` by joining Sprinzl coordinates, annotating known modifications, and shortening tRNA labels.
 
+* `identity_elements()`, `tertiary_contacts()`, and `modomics_mods()` documentation now notes that selenocysteine tRNA (SeC) is not currently supported (#30).
+
 * `identity_elements()` returns experimentally validated tRNA aminoacylation identity elements (determinants and antideterminants) for a given organism, based on Giege & Eriani (2023). Use `identity_organisms()` to list supported organisms.
 
 * `map_identity_to_trna()` converts Sprinzl-numbered identity elements to 1-based sequence positions for a specific tRNA, enabling overlay on `plot_tRNA_structure()` via the `outlines` parameter.
@@ -87,6 +89,8 @@
 * `compute_odds_ratios()` now uses a C++ implementation (via cpp11) for the pairwise Fisher's exact test inner loop, dramatically improving performance on large datasets. The odds ratio is now computed as the sample odds ratio with Haldane correction for zero cells, rather than the conditional MLE.
 
 * `fetch_modomics_mods()` downloads tRNA modification annotations from the MODOMICS database and maps them onto reference sequences using pairwise alignment (#11).
+
+* `modomics_mods()` now warns when a MODOMICS sequence has reference candidates but no alignment passes min_identity, instead of silently skipping (#30).
 
 * `modomics_mods()` maps MODOMICS tRNA modifications onto reference sequences using bundled data, eliminating the need for internet access. Use `modomics_organisms()` to list organisms with cached data. Falls back to `fetch_modomics_mods()` for unsupported organisms (#11).
 

--- a/R/identity.R
+++ b/R/identity.R
@@ -34,6 +34,13 @@
 #'   - `universal`: `TRUE` if conserved across all domains
 #'   - `description`: human-readable description
 #'
+#' @section Limitations:
+#' Selenocysteine tRNA (SeC, anticodon UCA) is not currently
+#' supported. Its non-canonical 90-nt structure with an extended
+#' variable arm is not represented in the bundled determinant or
+#' antideterminant tables, and Sprinzl coordinates for SeC tRNAs are
+#' likewise unavailable.
+#'
 #' @export
 #'
 #' @references
@@ -174,6 +181,12 @@ identity_organisms <- function() {
 #'     `"trans-WC"`, `"Levitt"`)
 #'   - `universal`: `TRUE` for contacts conserved across all domains
 #'   - `description`: human-readable description
+#'
+#' @section Limitations:
+#' Selenocysteine tRNA (SeC, anticodon UCA) is not currently
+#' supported. Its non-canonical 90-nt fold with an extended variable
+#' arm does not share the canonical tertiary contact set bundled
+#' here, and SeC Sprinzl coordinates are not available.
 #'
 #' @export
 #'

--- a/R/modomics.R
+++ b/R/modomics.R
@@ -23,6 +23,14 @@
 #'     (e.g., "1-methyladenosine")
 #'   - `mod1`: short modification name (e.g., "m1A")
 #'
+#' @section Limitations:
+#' Selenocysteine tRNA (SeC, anticodon UCA) is not currently
+#' supported. Its non-canonical 90-nt structure with an extended
+#' variable arm differs enough from canonical tRNAs that MODOMICS
+#' Sec sequences may fail to align at the default `min_identity`
+#' threshold; a warning is emitted in that case so the absence is
+#' visible rather than silent.
+#'
 #' @export
 #'
 #' @examples
@@ -456,6 +464,17 @@ match_modomics_to_refs <- function(
 
     valid <- identities >= min_identity
     if (!any(valid)) {
+      cli::cli_warn(
+        c(
+          "!" = paste0(
+            "No reference matched MODOMICS ",
+            "{.val {entry$subtype}-{entry$anticodon}} ",
+            "(length {nchar(entry$plain_seq)}) at ",
+            "min_identity = {min_identity}; best identity was ",
+            "{round(max(identities), 2)}."
+          )
+        )
+      )
       next
     }
 

--- a/R/modomics.R
+++ b/R/modomics.R
@@ -23,13 +23,14 @@
 #'     (e.g., "1-methyladenosine")
 #'   - `mod1`: short modification name (e.g., "m1A")
 #'
-#' @section Limitations:
-#' Selenocysteine tRNA (SeC, anticodon UCA) is not currently
-#' supported. Its non-canonical 90-nt structure with an extended
-#' variable arm differs enough from canonical tRNAs that MODOMICS
-#' Sec sequences may fail to align at the default `min_identity`
-#' threshold; a warning is emitted in that case so the absence is
-#' visible rather than silent.
+#' @section Alignment warnings:
+#' If a MODOMICS sequence is named-matched to candidate reference
+#' tRNAs but no candidate alignment reaches `min_identity`, a
+#' warning is emitted naming the subtype, anticodon, MODOMICS
+#' sequence length, and best observed identity. This surfaces
+#' silent skips (e.g., for non-canonical tRNAs or curated
+#' references that diverge from MODOMICS) so they are visible
+#' rather than dropped without notice.
 #'
 #' @export
 #'

--- a/man/identity_elements.Rd
+++ b/man/identity_elements.Rd
@@ -49,6 +49,15 @@ and antideterminants) for tRNA aminoacylation, based on data from
 Giege & Eriani (2023). Elements are defined per amino acid family
 using Sprinzl numbering.
 }
+\section{Limitations}{
+
+Selenocysteine tRNA (SeC, anticodon UCA) is not currently
+supported. Its non-canonical 90-nt structure with an extended
+variable arm is not represented in the bundled determinant or
+antideterminant tables, and Sprinzl coordinates for SeC tRNAs are
+likewise unavailable.
+}
+
 \examples{
 # All identity elements for E. coli
 identity_elements("Escherichia coli")

--- a/man/modomics_mods.Rd
+++ b/man/modomics_mods.Rd
@@ -36,14 +36,15 @@ alignment. No internet connection is required for organisms
 included in the package (see \code{\link[=modomics_organisms]{modomics_organisms()}}). For other
 organisms, falls back to \code{\link[=fetch_modomics_mods]{fetch_modomics_mods()}}.
 }
-\section{Limitations}{
+\section{Alignment warnings}{
 
-Selenocysteine tRNA (SeC, anticodon UCA) is not currently
-supported. Its non-canonical 90-nt structure with an extended
-variable arm differs enough from canonical tRNAs that MODOMICS
-Sec sequences may fail to align at the default \code{min_identity}
-threshold; a warning is emitted in that case so the absence is
-visible rather than silent.
+If a MODOMICS sequence is named-matched to candidate reference
+tRNAs but no candidate alignment reaches \code{min_identity}, a
+warning is emitted naming the subtype, anticodon, MODOMICS
+sequence length, and best observed identity. This surfaces
+silent skips (e.g., for non-canonical tRNAs or curated
+references that diverge from MODOMICS) so they are visible
+rather than dropped without notice.
 }
 
 \examples{

--- a/man/modomics_mods.Rd
+++ b/man/modomics_mods.Rd
@@ -36,6 +36,16 @@ alignment. No internet connection is required for organisms
 included in the package (see \code{\link[=modomics_organisms]{modomics_organisms()}}). For other
 organisms, falls back to \code{\link[=fetch_modomics_mods]{fetch_modomics_mods()}}.
 }
+\section{Limitations}{
+
+Selenocysteine tRNA (SeC, anticodon UCA) is not currently
+supported. Its non-canonical 90-nt structure with an extended
+variable arm differs enough from canonical tRNAs that MODOMICS
+Sec sequences may fail to align at the default \code{min_identity}
+threshold; a warning is emitted in that case so the absence is
+visible rather than silent.
+}
+
 \examples{
 \donttest{
 fa <- clover_example("ecoli/trna_only.fa.gz")

--- a/man/tertiary_contacts.Rd
+++ b/man/tertiary_contacts.Rd
@@ -40,6 +40,14 @@ constrain the tRNA fold and may indirectly affect aminoacylation
 specificity. Use \code{\link[=identity_elements]{identity_elements()}} for aaRS recognition
 determinants.
 }
+\section{Limitations}{
+
+Selenocysteine tRNA (SeC, anticodon UCA) is not currently
+supported. Its non-canonical 90-nt fold with an extended variable
+arm does not share the canonical tertiary contact set bundled
+here, and SeC Sprinzl coordinates are not available.
+}
+
 \examples{
 tertiary_contacts("Escherichia coli")
 

--- a/tests/testthat/_snaps/modomics.md
+++ b/tests/testthat/_snaps/modomics.md
@@ -1,0 +1,8 @@
+# match_modomics_to_refs warns when no alignment passes min_identity
+
+    Code
+      result <- match_modomics_to_refs(modomics_entries, ref_seq, min_identity = 1.01)
+    Condition
+      Warning:
+      ! No reference matched MODOMICS "Ala-AGC" (length 13) at min_identity = 1.01; best identity was 1.
+

--- a/tests/testthat/test-modomics.R
+++ b/tests/testthat/test-modomics.R
@@ -337,6 +337,20 @@ test_that("modomics_mods works with E. coli data", {
   expect_gt(nrow(mods), 0)
 })
 
+test_that("modomics_mods annotates non-canonical SeC tRNA (#30)", {
+  skip_if_not_installed("pwalign")
+
+  fa <- read_fasta(clover_example("ecoli/trna_only.fa.gz"))
+  sec_idx <- grep("SeC", names(fa))
+  expect_length(sec_idx, 1)
+
+  mods <- suppressMessages(modomics_mods(fa[sec_idx], "Escherichia coli"))
+
+  expect_setequal(mods$ref, names(fa)[sec_idx])
+  expect_setequal(mods$mod1, c("s4U", "D", "i6A", "m5U", "Y"))
+  expect_equal(sort(mods$pos), c(10L, 20L, 38L, 72L, 73L))
+})
+
 test_that("modomics_mods falls back for unsupported organism", {
   skip_if_not_installed("pwalign")
 

--- a/tests/testthat/test-modomics.R
+++ b/tests/testthat/test-modomics.R
@@ -164,6 +164,38 @@ test_that("find_aa_candidates returns empty for unknown AA", {
   expect_length(result, 0)
 })
 
+test_that("match_modomics_to_refs warns when no alignment passes min_identity", {
+  skip_if_not_installed("pwalign")
+
+  modomics_entries <- list(
+    list(
+      subtype = "Ala",
+      anticodon = "AGC",
+      mods = dplyr::tibble(
+        pos = 4L,
+        mod_full = "dihydrouridine",
+        mod1 = "D"
+      ),
+      plain_seq = "AUGUCGAUGUCGA"
+    )
+  )
+
+  # Candidate is found by name match, but min_identity > 1 guarantees
+  # no alignment can pass — triggers the warning code path.
+  ref_seq <- Biostrings::DNAStringSet("GGGGGGGGGGGGGGGGGGGG")
+  names(ref_seq) <- "tRNA-Ala-AGC-1"
+
+  expect_snapshot(
+    result <- match_modomics_to_refs(
+      modomics_entries,
+      ref_seq,
+      min_identity = 1.01
+    )
+  )
+
+  expect_equal(nrow(result), 0)
+})
+
 test_that("fetch_modomics_mods returns expected structure with mocked API", {
   skip_if_not_installed("httr2")
   skip_if_not_installed("jsonlite")


### PR DESCRIPTION
## Summary

Closes #30.

While investigating SeC visibility, confirmed that the MODOMICS
modification-annotation pipeline already works end-to-end for the
non-canonical E. coli SeC tRNA:

- `find_aa_candidates("Sec", names(fa))` finds `host-tRNA-SeC-TCA-1-1`
  via case-insensitive match.
- `pwalign::pairwiseAlignment()` reaches **100% identity (95/95 nt)**
  between the MODOMICS 95-nt Sec entry and the bundled SeC reference.
- All five MODOMICS modifications transfer to positions 10, 20, 38, 72,
  73 and render as colored circles + legend via
  `plot_tRNA_structure("tRNA-SeC-TCA", "Escherichia coli", ...)`.

This PR therefore corrects the docs and surfaces alignment failures as
a general diagnostic, rather than overclaiming SeC as unsupported.

### Changes

- `match_modomics_to_refs()` now emits `cli::cli_warn` when a MODOMICS
  sequence has reference candidates by name match but no alignment
  passes `min_identity`. Previously these were silently skipped.
- Replaced the "Limitations: SeC is not currently supported" section
  on `modomics_mods()` with an "Alignment warnings" section describing
  the new diagnostic. The warning is broadly useful (not SeC-specific).
- Retained `@section Limitations:` on `identity_elements()` and
  `tertiary_contacts()`: those are real gaps. The bundled
  `determinants.rds` has no SeC entries (verified: 20 amino acids, no
  Sec) and `ecoliK12_global_coords.tsv.gz` has no SeC `trna_id`
  (verified: 82 tRNAs, none with Sec/UCA/TCA).
- New regression test `modomics_mods annotates non-canonical SeC tRNA
  (#30)` pins the SeC modification set so future regex/alignment
  changes can't silently break the non-canonical case again.

## Test plan

- [x] `devtools::test()` — 528 PASS, 0 FAIL, 4 SKIP (unrelated: ggraph,
      rsvg).
- [x] `devtools::test(filter = '^modomics')` — 50 PASS.
- [x] `pkgdown::check_pkgdown()` clean.
- [x] Manually rendered `tRNA-SeC-TCA` via
      `plot_tRNA_structure("tRNA-SeC-TCA", "Escherichia coli",
      modifications = sec_mods)`: 5 mod circles at correct positions,
      full legend.